### PR TITLE
Remove unnecessary stdout redirect

### DIFF
--- a/scip-rust
+++ b/scip-rust
@@ -10,4 +10,4 @@ set -eux
 # crates (X1, X2, Y1 and Y2). So it is enough to run rust-analyzer once,
 # instead of once per workspace, or once per crate.
 
-rust-analyzer scip . > dump.scip
+rust-analyzer scip .


### PR DESCRIPTION
rust-analyzer writes the output directly to `index.scip`

Output redirection is a leftover from lsif-rust

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Ran scip-rust manually after making the change